### PR TITLE
Add relative and height prop to Flex component

### DIFF
--- a/src/layout/grid/Flex.ts
+++ b/src/layout/grid/Flex.ts
@@ -21,6 +21,8 @@ export type FlexProps = {
     | "space-around"
     | "initial"
     | "inherit";
+  relative?: boolean;
+  height?: string;
 };
 
 export const Flex = styled.div<FlexProps>`
@@ -54,6 +56,16 @@ export const Flex = styled.div<FlexProps>`
     column &&
     `display: flex;
      flex-direction: column; 
+  `};
+
+  ${({ relative }) =>
+      relative &&
+      `position: relative;
+  `};
+
+  ${({ height }) =>
+      height &&
+      `height: ${height};
   `};
   box-sizing: border-box;
 `;


### PR DESCRIPTION
We often wrap the <Flex/> component to add `height: 100%` or `position:relative`. With this PR we can do this using props.